### PR TITLE
Fix opacity control bug

### DIFF
--- a/src/basic-tools/tools/store.js
+++ b/src/basic-tools/tools/store.js
@@ -74,7 +74,15 @@ export default class Store {
 	 * @returns {number} - opacity value
 	 */
 	static get Opacity() {
-		return Number(localStorage.getItem("lode-opacity")) || 0.75;
+		// default opacity is set to 75%
+		let opacity = 0.75;
+		let storedOpacity = Number(localStorage.getItem("lode-opacity"));
+
+		if (storedOpacity || storedOpacity === 0){
+			opacity = storedOpacity;	
+		}
+
+		return opacity;
 	}
 	
 	/**


### PR DESCRIPTION
Opacity control now respects slider values of 0 and no longer sets a default value of 0.75 when a user sets the slider value to 0

fix #42 